### PR TITLE
Refactor videos page: client-side filtering and pagination

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
 npx lint-staged
+npm run type-check
+npm run test

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,7 +1,11 @@
 import { Metadata } from "next";
 import { Newsletter } from "@/components/Newsletter";
 import { PageHeader } from "@/components/PageHeader";
-import { getChannelInfo, formatViewCount } from "@/lib/youtube";
+import {
+  getChannelInfo,
+  getLatestVideos,
+  formatViewCount,
+} from "@/lib/youtube";
 import { newsletterFlag } from "@/app/flags";
 import { siteConfig } from "@/site.config";
 import styles from "./styles.module.css";
@@ -9,15 +13,21 @@ import styles from "./styles.module.css";
 export const metadata: Metadata = {
   title: "About | Foxy's Lab",
   description:
-    "Learn more about Foxy's Lab and our mission to make smart home technology accessible to everyone.",
+    "Meet the person behind Foxy's Lab — a smart home and homelab obsessive with strong opinions about local control and far too many Zigbee devices.",
 };
 
 export default async function AboutPage() {
-  const [channelResult, showNewsletter] = await Promise.all([
+  const [channelResult, videosResult, showNewsletter] = await Promise.all([
     getChannelInfo(),
+    getLatestVideos(50),
     newsletterFlag(),
   ]);
   const channel = channelResult.success ? channelResult.data : null;
+  const totalComments = videosResult.success
+    ? videosResult.data
+        .reduce((sum, v) => sum + parseInt(v.commentCount, 10), 0)
+        .toString()
+    : "0";
   return (
     <div className={`container-md ${styles.page}`}>
       <PageHeader
@@ -26,57 +36,72 @@ export default async function AboutPage() {
             About <span className="gradient-text">Foxy&apos;s Lab</span>
           </>
         }
-        subtitle="Making smart home technology accessible to everyone"
+        subtitle="One person, too many smart devices, a server rack that won't stop growing, and some strong opinions about local control"
       />
 
-      {/* Mission */}
+      {/* About */}
       <section className={styles.section}>
-        <h2 className={styles.sectionTitle}>Our Mission</h2>
+        <h2 className={styles.sectionTitle}>What&apos;s This All About?</h2>
         <div>
           <p className={styles.missionText}>
-            At Foxy&apos;s Lab, we believe that smart home technology should be
-            accessible, understandable, and fun for everyone. Whether
-            you&apos;re just getting started with your first smart bulb or
-            building complex home automation systems, we&apos;re here to guide
-            you every step of the way.
+            I started Foxy&apos;s Lab in September 2025, originally to impress a
+            prospective employer (honestly). Turns out I loved making videos, so
+            I kept going. What began as a bit of a career stunt turned into
+            something I genuinely care about.
           </p>
           <p className={styles.missionText}>
-            Our goal is to demystify smart home technology through clear,
-            practical tutorials that you can follow along with. We focus on
-            real-world applications, security best practices, and helping you
-            make informed decisions about the technology you bring into your
-            home.
+            The channel covers smart home tech and homelabs in roughly equal
+            measure, with the occasional bit of general tech thrown in when
+            something catches my eye. My thing is local control. I think your
+            smart home should work when your internet goes down. I think your
+            data should stay in your house. And I think you shouldn&apos;t need
+            a monthly subscription for a light switch to function. That
+            doesn&apos;t mean I reject anything cloud-based — if the cloud
+            genuinely adds value for you (not just for the company selling it),
+            that&apos;s fine. But if a device stops working the moment a server
+            goes offline for no good reason, I&apos;m going to have opinions
+            about that.
           </p>
         </div>
       </section>
 
-      {/* What We Cover */}
+      {/* What I Cover */}
       <section className={styles.section}>
-        <h2 className={styles.sectionTitle}>What We Cover</h2>
+        <h2 className={styles.sectionTitle}>What I Cover</h2>
         <div className={styles.topicGrid}>
           <div className={styles.topicCard}>
-            <h3 className={styles.topicTitle}>Smart Home Platforms</h3>
+            <h3 className={styles.topicTitle}>Smart Home & Homelab</h3>
             <p className={styles.topicDescription}>
-              Home Assistant, SmartThings, Google Home, Amazon Alexa, and more.
+              Home Assistant, self-hosted services, server builds, and the
+              platforms that tie it all together. These two worlds overlap more
+              than most people realise, and I cover both in equal measure.
             </p>
           </div>
           <div className={styles.topicCard}>
             <h3 className={styles.topicTitle}>Device Reviews</h3>
             <p className={styles.topicDescription}>
-              Honest reviews of smart devices, sensors, and automation hardware.
+              Whether I bought it, got sent it, or it&apos;s part of a paid deal
+              — every product gets the same honest shake. If a fifty quid sensor
+              falls apart after a month, you&apos;ll be the first to know.
             </p>
           </div>
           <div className={styles.topicCard}>
             <h3 className={styles.topicTitle}>Automation Tutorials</h3>
             <p className={styles.topicDescription}>
-              Step-by-step guides for creating useful automations and
-              integrations.
+              Practical, follow-along guides for smart home automations, homelab
+              setups, and self-hosted services. I try to explain the
+              &apos;why&apos; as well as the &apos;how&apos;, because
+              understanding what you&apos;re building matters more than just
+              copying my YAML.
             </p>
           </div>
           <div className={styles.topicCard}>
             <h3 className={styles.topicTitle}>Security & Privacy</h3>
             <p className={styles.topicDescription}>
-              Best practices for keeping your smart home secure and private.
+              Your smart home and your homelab shouldn&apos;t be a liability. I
+              talk about keeping things local, choosing devices and services
+              that respect your privacy, and why that cheap camera from a brand
+              you&apos;ve never heard of might not be the bargain it seems.
             </p>
           </div>
         </div>
@@ -84,6 +109,7 @@ export default async function AboutPage() {
 
       {/* Stats */}
       <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>The Story So Far</h2>
         <div className={styles.statsGrid}>
           <div>
             <div className={`${styles.statValue} gradient-text`}>
@@ -104,20 +130,30 @@ export default async function AboutPage() {
             <div className={styles.statLabel}>Views</div>
           </div>
           <div>
-            <div className={`${styles.statValue} gradient-text`}>100%</div>
-            <div className={styles.statLabel}>Passion</div>
+            <div className={`${styles.statValue} gradient-text`}>
+              {totalComments !== "0" ? formatViewCount(totalComments) : "—"}
+            </div>
+            <div className={styles.statLabel}>Comments</div>
           </div>
         </div>
+        <p className={styles.statsSubtext}>
+          Still early days — but every video is made with care, and I&apos;d
+          rather grow slowly with an audience that actually finds this useful
+          than chase numbers with clickbait.
+        </p>
       </section>
 
       {/* Community */}
       <section className={styles.section}>
-        <h2 className={styles.sectionTitle}>Join Our Community</h2>
+        <h2 className={styles.sectionTitle}>Come Say Hello</h2>
         <div className={styles.communityCard}>
           <p className={styles.communityText}>
-            We&apos;re more than just a YouTube channel - we&apos;re a community
-            of smart home enthusiasts sharing knowledge, troubleshooting
-            together, and pushing the boundaries of home automation.
+            I&apos;m building a community around this channel and honestly,
+            it&apos;s one of the best bits. The Discord has a mix of seasoned
+            smart home and homelab tinkerers and complete beginners, and
+            everyone&apos;s been lovely so far. If you want to chat about Home
+            Assistant, show off your server rack, argue about the best Zigbee
+            coordinator, or just lurk and learn — you&apos;re welcome.
           </p>
           <div className={styles.communityButtons}>
             <a

--- a/app/about/styles.module.css
+++ b/app/about/styles.module.css
@@ -64,21 +64,44 @@
   grid-template-columns: repeat(2, 1fr);
   gap: 2rem;
   text-align: center;
+  background-color: color-mix(in srgb, var(--secondary) 50%, transparent);
+  border: 1px solid color-mix(in srgb, var(--primary) 20%, transparent);
+  border-radius: 0.75rem;
+  padding: 2.5rem 1.5rem;
 }
 
 @media (min-width: 768px) {
   .statsGrid {
     grid-template-columns: repeat(4, 1fr);
+    padding: 3rem 2rem;
   }
 }
 
+.statsSubtext {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
+  margin-top: 1.5rem;
+  font-style: italic;
+}
+
 .statValue {
-  font-size: 2.25rem;
+  font-size: 2.75rem;
+  font-weight: 700;
   margin-bottom: 0.5rem;
+}
+
+@media (min-width: 768px) {
+  .statValue {
+    font-size: 3rem;
+  }
 }
 
 .statLabel {
   color: rgba(255, 255, 255, 0.6);
+  font-size: 1rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .communityCard {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -58,8 +58,9 @@ export default async function Home() {
             </h1>
 
             <p className={`${styles.heroSubtitle} text-balance`}>
-              Your ultimate destination for smart home technology, automation
-              tutorials, and cutting-edge tech education.
+              Smart home and homelab tech without the corporate waffle. Honest
+              reviews, local control advocacy, and the occasional
+              strongly-worded opinion about cloud-dependent tat.
             </p>
 
             <div className={styles.heroButtons}>
@@ -114,9 +115,30 @@ export default async function Home() {
         )}
       </section>
 
-      {/* Features Section */}
+      {/* Meet Foxy */}
       <section className={styles.section}>
-        <h2 className={styles.featuresTitle}>What You&apos;ll Learn</h2>
+        <div className={styles.introCard}>
+          <h2 className={styles.introTitle}>Who&apos;s This Then?</h2>
+          <p className={styles.introText}>
+            I&apos;m Foxy — I cover smart home tech, homelabs, and the
+            occasional bit of general tech that catches my eye. I started this
+            channel because I got fed up watching reviews that gloss over the
+            important stuff: does it work locally? Will the company still exist
+            in two years? Can you set it up without losing a weekend? Everything
+            here gets tested in my actual home (for better or worse), every
+            opinion is mine, and if something&apos;s rubbish, I&apos;ll tell
+            you.
+          </p>
+          <p className={styles.introCatchphrase}>
+            So... go grab a coffee, I&apos;ll get one too and then we&apos;ll
+            get into it.
+          </p>
+        </div>
+      </section>
+
+      {/* What's on the Channel */}
+      <section className={styles.section}>
+        <h2 className={styles.featuresTitle}>What&apos;s on the Channel</h2>
 
         <div className={styles.featuresGrid}>
           <div className={styles.featureCard}>
@@ -131,14 +153,16 @@ export default async function Home() {
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   strokeWidth={2}
-                  d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+                  d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
                 />
               </svg>
             </div>
-            <h3 className={styles.featureTitle}>Smart Home Basics</h3>
+            <h3 className={styles.featureTitle}>Local Control Matters</h3>
             <p className={styles.featureText}>
-              From choosing devices to setting up your first automation, we
-              cover everything you need to get started.
+              I&apos;m a firm believer that your smart home and your homelab
+              should work even when your internet doesn&apos;t. A big chunk of
+              what I do is about keeping your data and your devices under your
+              own roof.
             </p>
           </div>
 
@@ -154,14 +178,24 @@ export default async function Home() {
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   strokeWidth={2}
-                  d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
                 />
               </svg>
             </div>
-            <h3 className={styles.featureTitle}>Advanced Automation</h3>
+            <h3 className={styles.featureTitle}>Honest Reviews</h3>
             <p className={styles.featureText}>
-              Take your smart home to the next level with complex automations
-              and custom integrations.
+              I test smart home gear, homelab hardware, and the odd bit of
+              general tech, then tell you what I honestly think — whether I
+              bought it, was sent it, or it&apos;s part of a sponsorship. Every
+              product gets the same honest treatment. If it&apos;s brilliant,
+              I&apos;ll say so. If it&apos;s a waste of fifty quid, I&apos;ll
+              say that too.
             </p>
           </div>
 
@@ -177,14 +211,46 @@ export default async function Home() {
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   strokeWidth={2}
-                  d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+                  d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
                 />
               </svg>
             </div>
-            <h3 className={styles.featureTitle}>Security & Privacy</h3>
+            <h3 className={styles.featureTitle}>What the Heck?!</h3>
             <p className={styles.featureText}>
-              Learn best practices for keeping your smart home secure and
-              protecting your privacy.
+              My beginner-friendly series that explains smart home and homelab
+              concepts in plain English. Zigbee, Z-Wave, Docker, VLANs — all the
+              jargon that makes your eyes glaze over, broken down without the
+              condescension.
+            </p>
+          </div>
+
+          <div className={styles.featureCard}>
+            <div className={`${styles.featureIcon} gradient-primary`}>
+              <svg
+                className={styles.featureIconSvg}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+            </div>
+            <h3 className={styles.featureTitle}>Tutorials & Tinkering</h3>
+            <p className={styles.featureText}>
+              Step-by-step guides for people who want to get their hands dirty.
+              Home Assistant setups, homelab builds, self-hosted services, and
+              automations that actually make your life easier.
             </p>
           </div>
         </div>

--- a/app/styles.module.css
+++ b/app/styles.module.css
@@ -256,6 +256,49 @@
   margin-bottom: 1rem;
 }
 
+/* === Intro === */
+.introCard {
+  background-color: color-mix(in srgb, var(--secondary) 50%, transparent);
+  border: 1px solid color-mix(in srgb, var(--primary) 20%, transparent);
+  border-radius: 0.75rem;
+  padding: 2rem;
+  max-width: 56rem;
+  margin: 0 auto;
+}
+
+.introTitle {
+  font-size: 1.875rem;
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .introTitle {
+    font-size: 2.25rem;
+  }
+}
+
+.introText {
+  color: rgba(255, 255, 255, 0.8);
+  line-height: 1.75;
+  font-size: 1.0625rem;
+  text-align: center;
+}
+
+@media (min-width: 768px) {
+  .introText {
+    font-size: 1.125rem;
+  }
+}
+
+.introCatchphrase {
+  color: var(--primary-text);
+  font-style: italic;
+  font-size: 1.125rem;
+  text-align: center;
+  margin-top: 1.5rem;
+}
+
 /* === Features === */
 .featuresTitle {
   font-size: 1.875rem;
@@ -277,7 +320,7 @@
 
 @media (min-width: 768px) {
   .featuresGrid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 

--- a/app/videos/page.tsx
+++ b/app/videos/page.tsx
@@ -64,8 +64,18 @@ export default async function VideosPage() {
   // Build lookup maps
   const playlistVideoMap: Record<string, string[]> = {};
   const playlistSlugMap: Record<string, string> = {};
+  const videoIdSet = new Set(videos.map((v) => v.id));
+  const usedSlugs = new Set<string>();
+
   const playlistInfos = playlists.map((p, i) => {
-    const slug = toPlaylistSlug(p.title);
+    let slug = toPlaylistSlug(p.title, p.id);
+
+    // Disambiguate collisions by appending a suffix from the playlist ID
+    if (usedSlugs.has(slug)) {
+      slug = `${slug}-${p.id.slice(-6).toLowerCase()}`;
+    }
+    usedSlugs.add(slug);
+
     const videoIds = playlistIdResults[i].success
       ? playlistIdResults[i].data
       : [];
@@ -73,8 +83,6 @@ export default async function VideosPage() {
     playlistVideoMap[p.id] = videoIds;
     playlistSlugMap[slug] = p.id;
 
-    // Count how many of these videos are in our fetched set (after Shorts filtering)
-    const videoIdSet = new Set(videos.map((v) => v.id));
     const filteredCount = videoIds.filter((id) => videoIdSet.has(id)).length;
 
     return {

--- a/app/videos/page.tsx
+++ b/app/videos/page.tsx
@@ -1,13 +1,11 @@
-import { Suspense } from "react";
 import { Metadata } from "next";
-import { VideoCard } from "@/components/VideoCard";
-import { PlaylistFilter } from "@/components/PlaylistFilter";
 import {
   getLatestVideos,
   getPlaylists,
-  getPlaylistVideos,
+  getPlaylistVideoIds,
+  toPlaylistSlug,
 } from "@/lib/youtube";
-import { PageHeader } from "@/components/PageHeader";
+import { VideoGallery } from "@/components/VideoGallery";
 import { siteConfig } from "@/site.config";
 import styles from "./styles.module.css";
 
@@ -17,144 +15,88 @@ export const metadata: Metadata = {
     "Watch all the latest smart home tutorials, automation guides, and tech education videos from Foxy's Lab.",
 };
 
-interface VideosPageProps {
-  searchParams: Promise<{ playlist?: string }>;
-}
+export default async function VideosPage() {
+  const [videosResult, playlistsResult] = await Promise.all([
+    getLatestVideos(200),
+    getPlaylists(),
+  ]);
 
-async function VideoGrid({ playlistId }: { playlistId?: string }) {
-  const result = playlistId
-    ? await getPlaylistVideos(playlistId)
-    : await getLatestVideos(50);
-
-  if (!result.success) {
-    console.error("[VideoGrid] Failed to load videos:", result.error);
+  if (!videosResult.success) {
+    console.error("[VideosPage] Failed to load videos:", videosResult.error);
     return (
-      <div className={styles.errorState}>
-        <div className={styles.errorIcon}>
-          <svg
-            className={styles.errorIconSvg}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-            />
-          </svg>
+      <div className={`container ${styles.page}`}>
+        <div className={styles.errorState}>
+          <div className={styles.errorIcon}>
+            <svg
+              className={styles.errorIconSvg}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+          </div>
+          <p className={styles.errorTitle}>Unable to load videos right now</p>
+          <p className={styles.errorSubtitle}>
+            Please try again later or visit our YouTube channel directly.
+          </p>
+          <a href="/videos" className={styles.retryLink}>
+            Try Again
+          </a>
         </div>
-        <p className={styles.errorTitle}>Unable to load videos right now</p>
-        <p className={styles.errorSubtitle}>
-          Please try again later or visit our YouTube channel directly.
-        </p>
-        <a href="/videos" className={styles.retryLink}>
-          Try Again
-        </a>
       </div>
     );
   }
 
-  const videos = result.data;
-
-  if (videos.length === 0) {
-    return (
-      <div className={styles.emptyState}>
-        <div className={styles.emptyIcon}>
-          <svg
-            className={styles.emptyIconSvg}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
-            />
-          </svg>
-        </div>
-        <p className={styles.emptyText}>No videos in this playlist yet</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className={styles.videoGrid}>
-      {videos.map((video) => (
-        <VideoCard key={video.id} video={video} />
-      ))}
-    </div>
-  );
-}
-
-function VideoGridSkeleton() {
-  const SKELETON_COUNT = 6;
-  return (
-    <div role="status" aria-live="polite" aria-busy="true">
-      <span className="sr-only">Loading videos...</span>
-      <div className={styles.videoGrid}>
-        {[...Array(SKELETON_COUNT)].map((_, i) => (
-          <div
-            key={i}
-            className={`${styles.skeletonCard} ${styles.skeleton}`}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-export default async function VideosPage({ searchParams }: VideosPageProps) {
-  const params = await searchParams;
-  const playlistId = params.playlist;
-  const playlistsResult = await getPlaylists();
-
-  // Even if playlists fail to load, we can still show videos
+  const videos = videosResult.data;
   const playlists = playlistsResult.success ? playlistsResult.data : [];
 
-  const currentPlaylist = playlistId
-    ? playlists.find((p) => p.id === playlistId)
-    : null;
+  // Fetch video IDs for each playlist in parallel
+  const playlistIdResults = await Promise.all(
+    playlists.map((p) => getPlaylistVideoIds(p.id))
+  );
+
+  // Build lookup maps
+  const playlistVideoMap: Record<string, string[]> = {};
+  const playlistSlugMap: Record<string, string> = {};
+  const playlistInfos = playlists.map((p, i) => {
+    const slug = toPlaylistSlug(p.title);
+    const videoIds = playlistIdResults[i].success
+      ? playlistIdResults[i].data
+      : [];
+
+    playlistVideoMap[p.id] = videoIds;
+    playlistSlugMap[slug] = p.id;
+
+    // Count how many of these videos are in our fetched set (after Shorts filtering)
+    const videoIdSet = new Set(videos.map((v) => v.id));
+    const filteredCount = videoIds.filter((id) => videoIdSet.has(id)).length;
+
+    return {
+      id: p.id,
+      title: p.title,
+      slug,
+      itemCount: filteredCount,
+    };
+  });
+
+  // Only include playlists that have at least one matching video
+  const visiblePlaylists = playlistInfos.filter((p) => p.itemCount > 0);
 
   return (
     <div className={`container ${styles.page}`}>
-      <PageHeader
-        title={currentPlaylist ? currentPlaylist.title : "All Videos"}
-        subtitle={
-          currentPlaylist
-            ? currentPlaylist.description ||
-              `${currentPlaylist.itemCount} videos in this playlist`
-            : "Browse through our complete collection of tutorials and guides"
-        }
+      <VideoGallery
+        videos={videos}
+        playlists={visiblePlaylists}
+        playlistVideoMap={playlistVideoMap}
+        playlistSlugMap={playlistSlugMap}
       />
 
-      {/* Playlist Filter - No Suspense needed as playlists are already awaited */}
-      {playlists.length > 0 && <PlaylistFilter playlists={playlists} />}
-
-      {/* Show error if playlists failed but we still want to show videos */}
-      {!playlistsResult.success && (
-        <>
-          {console.error(
-            "[VideosPage] Failed to load playlists:",
-            playlistsResult.error
-          )}
-          <div className={styles.playlistWarning}>
-            <p className={styles.playlistWarningText}>
-              Unable to load playlist filters. Showing all videos.
-            </p>
-          </div>
-        </>
-      )}
-
-      {/* Video Grid - Key prop forces re-render when playlist changes */}
-      <Suspense key={playlistId || "all"} fallback={<VideoGridSkeleton />}>
-        <VideoGrid playlistId={playlistId} />
-      </Suspense>
-
-      {/* View on YouTube */}
       <div className={styles.ctaWrapper}>
         <a
           href={siteConfig.social.youtubeVideos}

--- a/app/videos/page.tsx
+++ b/app/videos/page.tsx
@@ -6,6 +6,7 @@ import {
   toPlaylistSlug,
 } from "@/lib/youtube";
 import { VideoGallery } from "@/components/VideoGallery";
+import { PageHeader } from "@/components/PageHeader";
 import { siteConfig } from "@/site.config";
 import styles from "./styles.module.css";
 
@@ -25,6 +26,10 @@ export default async function VideosPage() {
     console.error("[VideosPage] Failed to load videos:", videosResult.error);
     return (
       <div className={`container ${styles.page}`}>
+        <PageHeader
+          title="All Videos"
+          subtitle="Browse through our complete collection of tutorials and guides"
+        />
         <div className={styles.errorState}>
           <div className={styles.errorIcon}>
             <svg

--- a/app/videos/styles.module.css
+++ b/app/videos/styles.module.css
@@ -8,24 +8,6 @@
   }
 }
 
-.videoGrid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 2rem;
-}
-
-@media (min-width: 768px) {
-  .videoGrid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1024px) {
-  .videoGrid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
 .errorState {
   text-align: center;
   padding: 3rem 0;
@@ -73,56 +55,6 @@
 
 .retryLink:hover {
   opacity: 0.8;
-}
-
-.emptyState {
-  text-align: center;
-  padding: 3rem 0;
-}
-
-.emptyIcon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 4rem;
-  height: 4rem;
-  border-radius: 9999px;
-  background-color: color-mix(in srgb, var(--secondary) 50%, transparent);
-  margin-bottom: 1rem;
-}
-
-.emptyIconSvg {
-  width: 2rem;
-  height: 2rem;
-  color: rgba(255, 255, 255, 0.5);
-}
-
-.emptyText {
-  color: rgba(255, 255, 255, 0.7);
-  font-size: 1.125rem;
-}
-
-.skeleton {
-  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-}
-
-.skeletonCard {
-  background-color: color-mix(in srgb, var(--secondary) 50%, transparent);
-  border-radius: 0.75rem;
-  aspect-ratio: 16 / 9;
-}
-
-.playlistWarning {
-  margin-bottom: 2rem;
-  padding: 1rem;
-  background-color: rgba(234, 179, 8, 0.1);
-  border: 1px solid rgba(234, 179, 8, 0.3);
-  border-radius: 0.5rem;
-}
-
-.playlistWarningText {
-  color: #eab308;
-  font-size: 0.875rem;
 }
 
 .ctaWrapper {

--- a/components/PlaylistFilter/__tests__/PlaylistFilter.test.tsx
+++ b/components/PlaylistFilter/__tests__/PlaylistFilter.test.tsx
@@ -1,13 +1,31 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@/test/test-utils";
 import userEvent from "@testing-library/user-event";
-import { useRouter, useSearchParams } from "next/navigation";
 import { PlaylistFilter } from "../index";
-import { mockPlaylist, mockPlaylist2 } from "@/test/fixtures/youtube";
+
+const mockPlaylist = {
+  id: "PLabc123",
+  title: "Home Assistant Tutorials",
+  slug: "home-assistant-tutorials",
+  itemCount: 12,
+};
+
+const mockPlaylist2 = {
+  id: "PLdef456",
+  title: "Smart Home Basics",
+  slug: "smart-home-basics",
+  itemCount: 8,
+};
 
 describe("PlaylistFilter", () => {
   it("renders 'All Videos' pill plus playlist pills", () => {
-    render(<PlaylistFilter playlists={[mockPlaylist, mockPlaylist2]} />);
+    render(
+      <PlaylistFilter
+        playlists={[mockPlaylist, mockPlaylist2]}
+        activeSlug={null}
+        onSelect={vi.fn()}
+      />
+    );
 
     expect(
       screen.getByRole("button", { name: "Show all videos" })
@@ -25,21 +43,27 @@ describe("PlaylistFilter", () => {
   });
 
   it("'All Videos' is pressed when no playlist is selected", () => {
-    render(<PlaylistFilter playlists={[mockPlaylist]} />);
+    render(
+      <PlaylistFilter
+        playlists={[mockPlaylist]}
+        activeSlug={null}
+        onSelect={vi.fn()}
+      />
+    );
 
     expect(
       screen.getByRole("button", { name: "Show all videos" })
     ).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("shows playlist as pressed when selected via search params", () => {
-    vi.mocked(useSearchParams).mockReturnValue(
-      new URLSearchParams(`playlist=${mockPlaylist.id}`) as ReturnType<
-        typeof useSearchParams
-      >
+  it("shows playlist as pressed when activeSlug matches", () => {
+    render(
+      <PlaylistFilter
+        playlists={[mockPlaylist]}
+        activeSlug={mockPlaylist.slug}
+        onSelect={vi.fn()}
+      />
     );
-
-    render(<PlaylistFilter playlists={[mockPlaylist]} />);
 
     expect(
       screen.getByRole("button", {
@@ -51,19 +75,17 @@ describe("PlaylistFilter", () => {
     ).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("calls router.push when a playlist pill is clicked", async () => {
-    const mockPush = vi.fn();
-    vi.mocked(useRouter).mockReturnValue({
-      push: mockPush,
-      replace: vi.fn(),
-      back: vi.fn(),
-      forward: vi.fn(),
-      refresh: vi.fn(),
-      prefetch: vi.fn(),
-    });
-
+  it("calls onSelect with slug when a playlist pill is clicked", async () => {
+    const onSelect = vi.fn();
     const user = userEvent.setup();
-    render(<PlaylistFilter playlists={[mockPlaylist]} />);
+
+    render(
+      <PlaylistFilter
+        playlists={[mockPlaylist]}
+        activeSlug={null}
+        onSelect={onSelect}
+      />
+    );
 
     await user.click(
       screen.getByRole("button", {
@@ -71,20 +93,42 @@ describe("PlaylistFilter", () => {
       })
     );
 
-    expect(mockPush).toHaveBeenCalledWith(
-      expect.stringContaining(`playlist=${mockPlaylist.id}`),
-      { scroll: false }
+    expect(onSelect).toHaveBeenCalledWith(mockPlaylist.slug);
+  });
+
+  it("calls onSelect with null when 'All Videos' is clicked", async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <PlaylistFilter
+        playlists={[mockPlaylist]}
+        activeSlug={mockPlaylist.slug}
+        onSelect={onSelect}
+      />
     );
+
+    await user.click(screen.getByRole("button", { name: "Show all videos" }));
+
+    expect(onSelect).toHaveBeenCalledWith(null);
   });
 
   it("displays item count for each playlist", () => {
-    render(<PlaylistFilter playlists={[mockPlaylist]} />);
+    render(
+      <PlaylistFilter
+        playlists={[mockPlaylist]}
+        activeSlug={null}
+        onSelect={vi.fn()}
+      />
+    );
 
     expect(screen.getByText(`(${mockPlaylist.itemCount})`)).toBeInTheDocument();
   });
 
   it("renders empty state with just 'All Videos'", () => {
-    render(<PlaylistFilter playlists={[]} />);
+    render(
+      <PlaylistFilter playlists={[]} activeSlug={null} onSelect={vi.fn()} />
+    );
 
     expect(screen.getAllByRole("button")).toHaveLength(1);
     expect(

--- a/components/PlaylistFilter/index.tsx
+++ b/components/PlaylistFilter/index.tsx
@@ -1,33 +1,23 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { useTransition } from "react";
-import { YouTubePlaylist } from "@/types/youtube";
 import styles from "./styles.module.css";
 
 interface PlaylistFilterProps {
-  playlists: YouTubePlaylist[];
+  playlists: Array<{
+    id: string;
+    title: string;
+    slug: string;
+    itemCount: number;
+  }>;
+  activeSlug: string | null;
+  onSelect: (slug: string | null) => void;
 }
 
-export function PlaylistFilter({ playlists }: PlaylistFilterProps) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const currentPlaylist = searchParams.get("playlist");
-  const [isPending, startTransition] = useTransition();
-
-  const handleFilterClick = (playlistId: string | null) => {
-    const params = new URLSearchParams(searchParams.toString());
-    if (playlistId) {
-      params.set("playlist", playlistId);
-    } else {
-      params.delete("playlist");
-    }
-
-    startTransition(() => {
-      router.push(`/videos?${params.toString()}`, { scroll: false });
-    });
-  };
-
+export function PlaylistFilter({
+  playlists,
+  activeSlug,
+  onSelect,
+}: PlaylistFilterProps) {
   return (
     <div
       className={styles.wrapper}
@@ -36,86 +26,32 @@ export function PlaylistFilter({ playlists }: PlaylistFilterProps) {
     >
       <div className={styles.pills}>
         <button
-          onClick={() => handleFilterClick(null)}
-          disabled={isPending}
-          aria-pressed={!currentPlaylist}
+          onClick={() => onSelect(null)}
+          aria-pressed={!activeSlug}
           aria-label="Show all videos"
-          className={`${styles.pill} ${!currentPlaylist ? styles.pillActive : styles.pillInactive}`}
+          className={`${styles.pill} ${!activeSlug ? styles.pillActive : styles.pillInactive}`}
         >
-          {isPending && !currentPlaylist ? (
-            <span className={styles.loading}>
-              <svg className={styles.spinner} viewBox="0 0 24 24">
-                <circle
-                  className={styles.spinnerBg}
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                  fill="none"
-                />
-                <path
-                  className={styles.spinnerFg}
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                />
-              </svg>
-              Loading...
-            </span>
-          ) : (
-            "All Videos"
-          )}
+          All Videos
         </button>
         {playlists.map((playlist) => {
-          const isActive = currentPlaylist === playlist.id;
-          const isLoading = isPending && isActive;
+          const isActive = activeSlug === playlist.slug;
 
           return (
             <button
               key={playlist.id}
-              onClick={() => handleFilterClick(playlist.id)}
-              disabled={isPending}
+              onClick={() => onSelect(playlist.slug)}
               aria-pressed={isActive}
               aria-label={`Filter by ${playlist.title}, ${playlist.itemCount} videos`}
               className={`${styles.pill} ${isActive ? styles.pillActive : styles.pillInactive}`}
             >
-              {isLoading ? (
-                <span className={styles.loading}>
-                  <svg className={styles.spinner} viewBox="0 0 24 24">
-                    <circle
-                      className={styles.spinnerBg}
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                      fill="none"
-                    />
-                    <path
-                      className={styles.spinnerFg}
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    />
-                  </svg>
-                  Loading...
-                </span>
-              ) : (
-                <>
-                  {playlist.title}
-                  <span className={styles.count} aria-hidden="true">
-                    ({playlist.itemCount})
-                  </span>
-                </>
-              )}
+              {playlist.title}
+              <span className={styles.count} aria-hidden="true">
+                ({playlist.itemCount})
+              </span>
             </button>
           );
         })}
       </div>
-      {isPending && (
-        <div className="sr-only" role="status" aria-live="polite">
-          Loading videos...
-        </div>
-      )}
     </div>
   );
 }

--- a/components/PlaylistFilter/index.tsx
+++ b/components/PlaylistFilter/index.tsx
@@ -1,14 +1,10 @@
 "use client";
 
+import { PlaylistInfo } from "@/types/youtube";
 import styles from "./styles.module.css";
 
 interface PlaylistFilterProps {
-  playlists: Array<{
-    id: string;
-    title: string;
-    slug: string;
-    itemCount: number;
-  }>;
+  playlists: PlaylistInfo[];
   activeSlug: string | null;
   onSelect: (slug: string | null) => void;
 }

--- a/components/PlaylistFilter/styles.module.css
+++ b/components/PlaylistFilter/styles.module.css
@@ -20,10 +20,6 @@
   cursor: pointer;
 }
 
-.pill:disabled {
-  opacity: 0.5;
-}
-
 .pillActive {
   background-color: var(--primary);
   color: white;
@@ -37,26 +33,6 @@
 
 .pillInactive:hover {
   border-color: color-mix(in srgb, var(--primary) 50%, transparent);
-}
-
-.loading {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.spinner {
-  animation: spin 1s linear infinite;
-  height: 1rem;
-  width: 1rem;
-}
-
-.spinnerBg {
-  opacity: 0.25;
-}
-
-.spinnerFg {
-  opacity: 0.75;
 }
 
 .count {

--- a/components/VideoCard/__tests__/VideoCard.test.tsx
+++ b/components/VideoCard/__tests__/VideoCard.test.tsx
@@ -11,13 +11,6 @@ describe("VideoCard", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders video description", () => {
-    render(<VideoCard video={mockVideo} />);
-    expect(
-      screen.getByText("Learn how to set up Home Assistant from scratch.")
-    ).toBeInTheDocument();
-  });
-
   it("renders formatted view count", () => {
     render(<VideoCard video={mockVideo} />);
     expect(screen.getByText("15.0K views")).toBeInTheDocument();

--- a/components/VideoCard/index.tsx
+++ b/components/VideoCard/index.tsx
@@ -33,10 +33,10 @@ export function VideoCard({ video }: VideoCardProps) {
         {/* Content */}
         <div>
           <h3 className={styles.title}>{video.title}</h3>
-          <p className={styles.description}>{video.description}</p>
           <div className={styles.meta}>
             <span>{formatViewCount(video.viewCount)} views</span>
             <span>{formatViewCount(video.likeCount)} likes</span>
+            <span>{formatViewCount(video.commentCount)} comments</span>
           </div>
         </div>
       </a>

--- a/components/VideoGallery/__tests__/VideoGallery.test.tsx
+++ b/components/VideoGallery/__tests__/VideoGallery.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import userEvent from "@testing-library/user-event";
+import { useRouter, useSearchParams } from "next/navigation";
+import { VideoGallery } from "../index";
+import { mockVideo, mockVideo2 } from "@/test/fixtures/youtube";
+import type { YouTubeVideo } from "@/types/youtube";
+
+function buildVideos(count: number): YouTubeVideo[] {
+  return Array.from({ length: count }, (_, i) => ({
+    ...mockVideo,
+    id: `video-${i}`,
+    title: `Video ${i + 1}`,
+  }));
+}
+
+const playlists = [
+  { id: "PL1", title: "Tutorials", slug: "tutorials", itemCount: 2 },
+  { id: "PL2", title: "Reviews", slug: "reviews", itemCount: 1 },
+];
+
+const playlistVideoMap: Record<string, string[]> = {
+  PL1: [mockVideo.id, mockVideo2.id],
+  PL2: [mockVideo2.id],
+};
+
+const playlistSlugMap: Record<string, string> = {
+  tutorials: "PL1",
+  reviews: "PL2",
+};
+
+const defaultProps = {
+  videos: [mockVideo, mockVideo2],
+  playlists,
+  playlistVideoMap,
+  playlistSlugMap,
+};
+
+describe("VideoGallery", () => {
+  it("renders all videos when no playlist is selected", () => {
+    render(<VideoGallery {...defaultProps} />);
+
+    expect(screen.getByText(mockVideo.title)).toBeInTheDocument();
+    expect(screen.getByText(mockVideo2.title)).toBeInTheDocument();
+  });
+
+  it("renders page header with 'All Videos' when no filter active", () => {
+    render(<VideoGallery {...defaultProps} />);
+
+    expect(
+      screen.getByRole("heading", { name: "All Videos" })
+    ).toBeInTheDocument();
+  });
+
+  it("filters videos when playlist slug is in URL", () => {
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("playlist=reviews") as ReturnType<
+        typeof useSearchParams
+      >
+    );
+
+    render(<VideoGallery {...defaultProps} />);
+
+    expect(screen.getByText(mockVideo2.title)).toBeInTheDocument();
+    expect(screen.queryByText(mockVideo.title)).not.toBeInTheDocument();
+  });
+
+  it("shows all videos when URL contains an invalid slug", () => {
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("playlist=nonexistent") as ReturnType<
+        typeof useSearchParams
+      >
+    );
+
+    render(<VideoGallery {...defaultProps} />);
+
+    expect(screen.getByText(mockVideo.title)).toBeInTheDocument();
+    expect(screen.getByText(mockVideo2.title)).toBeInTheDocument();
+  });
+
+  it("calls router.push with slug when playlist is selected", async () => {
+    const mockPush = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({
+      push: mockPush,
+      replace: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      prefetch: vi.fn(),
+    });
+
+    const user = userEvent.setup();
+    render(<VideoGallery {...defaultProps} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Filter by Tutorials, 2 videos",
+      })
+    );
+
+    expect(mockPush).toHaveBeenCalledWith("/videos?playlist=tutorials", {
+      scroll: false,
+    });
+  });
+
+  it("does not show pagination when 12 or fewer videos", () => {
+    render(<VideoGallery {...defaultProps} />);
+
+    expect(
+      screen.queryByRole("navigation", { name: "Video pagination" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows pagination when more than 12 videos", () => {
+    const manyVideos = buildVideos(15);
+
+    render(
+      <VideoGallery
+        {...defaultProps}
+        videos={manyVideos}
+        playlistVideoMap={{}}
+        playlistSlugMap={{}}
+      />
+    );
+
+    expect(
+      screen.getByRole("navigation", { name: "Video pagination" })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Page 1")).toBeInTheDocument();
+    expect(screen.getByLabelText("Page 2")).toBeInTheDocument();
+  });
+
+  it("shows empty state when filtered playlist has no matching videos", () => {
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("playlist=tutorials") as ReturnType<
+        typeof useSearchParams
+      >
+    );
+
+    render(
+      <VideoGallery
+        {...defaultProps}
+        videos={[]}
+        playlistVideoMap={{ PL1: ["nonexistent"] }}
+      />
+    );
+
+    expect(
+      screen.getByText("No videos in this playlist yet")
+    ).toBeInTheDocument();
+  });
+});

--- a/components/VideoGallery/index.tsx
+++ b/components/VideoGallery/index.tsx
@@ -2,20 +2,13 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
-import { YouTubeVideo } from "@/types/youtube";
+import { YouTubeVideo, PlaylistInfo } from "@/types/youtube";
 import { VideoCard } from "@/components/VideoCard";
 import { PlaylistFilter } from "@/components/PlaylistFilter";
 import { PageHeader } from "@/components/PageHeader";
 import styles from "./styles.module.css";
 
 const VIDEOS_PER_PAGE = 12;
-
-interface PlaylistInfo {
-  id: string;
-  title: string;
-  slug: string;
-  itemCount: number;
-}
 
 interface VideoGalleryProps {
   videos: YouTubeVideo[];

--- a/components/VideoGallery/index.tsx
+++ b/components/VideoGallery/index.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+import { YouTubeVideo } from "@/types/youtube";
+import { VideoCard } from "@/components/VideoCard";
+import { PlaylistFilter } from "@/components/PlaylistFilter";
+import { PageHeader } from "@/components/PageHeader";
+import styles from "./styles.module.css";
+
+const VIDEOS_PER_PAGE = 12;
+
+interface PlaylistInfo {
+  id: string;
+  title: string;
+  slug: string;
+  itemCount: number;
+}
+
+interface VideoGalleryProps {
+  videos: YouTubeVideo[];
+  playlists: PlaylistInfo[];
+  playlistVideoMap: Record<string, string[]>;
+  playlistSlugMap: Record<string, string>;
+}
+
+export function VideoGallery({
+  videos,
+  playlists,
+  playlistVideoMap,
+  playlistSlugMap,
+}: VideoGalleryProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const activeSlug = searchParams.get("playlist");
+  const pageParam = searchParams.get("page");
+  const currentPage = Math.max(1, parseInt(pageParam || "1", 10) || 1);
+
+  const activePlaylistId = activeSlug
+    ? playlistSlugMap[activeSlug] || null
+    : null;
+
+  const activePlaylist = activePlaylistId
+    ? playlists.find((p) => p.id === activePlaylistId)
+    : null;
+
+  const filteredVideos = useMemo(() => {
+    if (!activePlaylistId) return videos;
+
+    const videoIds = playlistVideoMap[activePlaylistId];
+    if (!videoIds) return videos;
+
+    const idSet = new Set(videoIds);
+    return videos.filter((v) => idSet.has(v.id));
+  }, [videos, activePlaylistId, playlistVideoMap]);
+
+  const totalPages = Math.ceil(filteredVideos.length / VIDEOS_PER_PAGE);
+  const safePage = Math.min(currentPage, Math.max(1, totalPages));
+  const startIndex = (safePage - 1) * VIDEOS_PER_PAGE;
+  const paginatedVideos = filteredVideos.slice(
+    startIndex,
+    startIndex + VIDEOS_PER_PAGE
+  );
+
+  function updateUrl(slug: string | null, page: number) {
+    const params = new URLSearchParams();
+    if (slug) params.set("playlist", slug);
+    if (page > 1) params.set("page", String(page));
+    const qs = params.toString();
+    router.push(qs ? `/videos?${qs}` : "/videos", { scroll: false });
+  }
+
+  function handlePlaylistSelect(slug: string | null) {
+    updateUrl(slug, 1);
+  }
+
+  function handlePageChange(page: number) {
+    updateUrl(activeSlug, page);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }
+
+  // Generate page numbers with ellipsis for large ranges
+  function getPageNumbers(): (number | "ellipsis")[] {
+    if (totalPages <= 7) {
+      return Array.from({ length: totalPages }, (_, i) => i + 1);
+    }
+
+    const pages: (number | "ellipsis")[] = [1];
+
+    if (safePage > 3) pages.push("ellipsis");
+
+    const start = Math.max(2, safePage - 1);
+    const end = Math.min(totalPages - 1, safePage + 1);
+    for (let i = start; i <= end; i++) {
+      pages.push(i);
+    }
+
+    if (safePage < totalPages - 2) pages.push("ellipsis");
+
+    pages.push(totalPages);
+    return pages;
+  }
+
+  return (
+    <>
+      <PageHeader
+        title={activePlaylist ? activePlaylist.title : "All Videos"}
+        subtitle={
+          activePlaylist
+            ? `${filteredVideos.length} videos in this playlist`
+            : "Browse through our complete collection of tutorials and guides"
+        }
+      />
+
+      {playlists.length > 0 && (
+        <PlaylistFilter
+          playlists={playlists}
+          activeSlug={activeSlug}
+          onSelect={handlePlaylistSelect}
+        />
+      )}
+
+      {paginatedVideos.length === 0 ? (
+        <div className={styles.emptyState}>
+          <div className={styles.emptyIcon}>
+            <svg
+              className={styles.emptyIconSvg}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
+              />
+            </svg>
+          </div>
+          <p className={styles.emptyText}>No videos in this playlist yet</p>
+        </div>
+      ) : (
+        <>
+          <div className={styles.videoGrid}>
+            {paginatedVideos.map((video) => (
+              <VideoCard key={video.id} video={video} />
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <nav
+              className={styles.pagination}
+              role="navigation"
+              aria-label="Video pagination"
+            >
+              <button
+                className={styles.pageNav}
+                onClick={() => handlePageChange(safePage - 1)}
+                disabled={safePage <= 1}
+                aria-label="Previous page"
+              >
+                Prev
+              </button>
+
+              {getPageNumbers().map((item, index) =>
+                item === "ellipsis" ? (
+                  <span key={`ellipsis-${index}`} aria-hidden="true">
+                    &hellip;
+                  </span>
+                ) : (
+                  <button
+                    key={item}
+                    className={`${styles.pageButton} ${item === safePage ? styles.pageButtonActive : ""}`}
+                    onClick={() => handlePageChange(item)}
+                    aria-label={`Page ${item}`}
+                    aria-current={item === safePage ? "page" : undefined}
+                  >
+                    {item}
+                  </button>
+                )
+              )}
+
+              <button
+                className={styles.pageNav}
+                onClick={() => handlePageChange(safePage + 1)}
+                disabled={safePage >= totalPages}
+                aria-label="Next page"
+              >
+                Next
+              </button>
+            </nav>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/components/VideoGallery/styles.module.css
+++ b/components/VideoGallery/styles.module.css
@@ -1,0 +1,107 @@
+.videoGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+}
+
+@media (min-width: 768px) {
+  .videoGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .videoGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.emptyState {
+  text-align: center;
+  padding: 3rem 0;
+}
+
+.emptyIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 4rem;
+  height: 4rem;
+  border-radius: 9999px;
+  background-color: color-mix(in srgb, var(--secondary) 50%, transparent);
+  margin-bottom: 1rem;
+}
+
+.emptyIconSvg {
+  width: 2rem;
+  height: 2rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.emptyText {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 1.125rem;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 2.5rem;
+  flex-wrap: wrap;
+}
+
+.pageButton {
+  min-width: 2.5rem;
+  height: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
+  border: 1px solid color-mix(in srgb, var(--primary) 30%, transparent);
+  background-color: color-mix(in srgb, var(--secondary) 50%, transparent);
+  color: rgba(255, 255, 255, 0.8);
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+}
+
+.pageButton:hover {
+  border-color: color-mix(in srgb, var(--primary) 60%, transparent);
+}
+
+.pageButtonActive {
+  background-color: var(--primary);
+  border-color: var(--primary);
+  color: white;
+  cursor: default;
+}
+
+.pageNav {
+  height: 2.5rem;
+  padding: 0 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
+  border: 1px solid color-mix(in srgb, var(--primary) 30%, transparent);
+  background-color: color-mix(in srgb, var(--secondary) 50%, transparent);
+  color: rgba(255, 255, 255, 0.8);
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+}
+
+.pageNav:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--primary) 60%, transparent);
+}
+
+.pageNav:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -115,6 +115,7 @@ interface YouTubeApiChannelResponse {
       subscriberCount: string;
       videoCount: string;
       viewCount: string;
+      commentCount: string;
     };
     contentDetails: {
       relatedPlaylists: {
@@ -159,6 +160,7 @@ interface YouTubeApiVideoResponse {
     statistics: {
       viewCount: string;
       likeCount: string;
+      commentCount: string;
     };
     contentDetails: {
       duration: string;
@@ -293,6 +295,7 @@ async function fetchVideoDetails(
         publishedAt: video.snippet.publishedAt,
         viewCount: video.statistics.viewCount || "0",
         likeCount: video.statistics.likeCount || "0",
+        commentCount: video.statistics.commentCount || "0",
         duration: video.contentDetails.duration,
         url: `https://www.youtube.com/watch?v=${video.id}`,
       }));
@@ -415,6 +418,7 @@ export async function getChannelInfo(): Promise<ApiResult<YouTubeChannel>> {
           subscriberCount: channel.statistics.subscriberCount,
           videoCount: channel.statistics.videoCount,
           viewCount: channel.statistics.viewCount,
+          commentCount: channel.statistics.commentCount || "0",
           thumbnail:
             channel.snippet.thumbnails.high?.url ||
             channel.snippet.thumbnails.medium?.url ||

--- a/site.config.ts
+++ b/site.config.ts
@@ -8,11 +8,11 @@
 export const siteConfig = {
   // Site Identity
   name: "Foxy's Lab",
-  tagline: "Smart Home & Tech Education",
+  tagline: "Smart Home, Homelab & Tech",
   description:
-    "Join Foxy's Lab for expert tutorials on smart home technology, home automation, and tech education. Learn, build, and automate with confidence.",
+    "Foxy's Lab — honest smart home and homelab reviews, local control advocacy, and beginner-friendly tech tutorials from a bloke who tests everything in his actual house.",
   shortDescription:
-    "Your guide to smart home technology, automation, and tech education.",
+    "Smart home and homelab tech, honest opinions, and a healthy distrust of cloud-only devices.",
 
   // URLs
   url: "https://www.foxyslab.com",

--- a/test/fixtures/youtube.ts
+++ b/test/fixtures/youtube.ts
@@ -8,6 +8,7 @@ export const mockVideo: YouTubeVideo = {
   publishedAt: "2025-06-15T12:00:00Z",
   viewCount: "15000",
   likeCount: "850",
+  commentCount: "42",
   duration: "PT12M30S",
   url: "https://www.youtube.com/watch?v=abc123",
 };
@@ -20,6 +21,7 @@ export const mockVideo2: YouTubeVideo = {
   publishedAt: "2025-07-01T14:00:00Z",
   viewCount: "8500",
   likeCount: "420",
+  commentCount: "28",
   duration: "PT8M15S",
   url: "https://www.youtube.com/watch?v=def456",
 };

--- a/types/youtube.ts
+++ b/types/youtube.ts
@@ -18,7 +18,7 @@ export interface YouTubeChannel {
   subscriberCount: string;
   videoCount: string;
   viewCount: string;
-  commentCount: string;
+  commentCount?: string;
   thumbnail: string;
 }
 
@@ -27,5 +27,12 @@ export interface YouTubePlaylist {
   title: string;
   description: string;
   thumbnail: string;
+  itemCount: number;
+}
+
+export interface PlaylistInfo {
+  id: string;
+  title: string;
+  slug: string;
   itemCount: number;
 }

--- a/types/youtube.ts
+++ b/types/youtube.ts
@@ -6,6 +6,7 @@ export interface YouTubeVideo {
   publishedAt: string;
   viewCount: string;
   likeCount: string;
+  commentCount: string;
   duration: string;
   url: string;
 }
@@ -17,6 +18,7 @@ export interface YouTubeChannel {
   subscriberCount: string;
   videoCount: string;
   viewCount: string;
+  commentCount: string;
   thumbnail: string;
 }
 


### PR DESCRIPTION
## Summary

- **Rewrite homepage and about page copy** to match the channel's casual, enthusiastic voice
- **Refactor videos page** to load all video data once at page load, then handle playlist filtering and pagination entirely client-side — eliminates the visible loading delay on every filter change
- **Replace raw YouTube API playlist IDs** in URLs with human-readable slugs (e.g. `?playlist=home-assistant-tutorials` instead of `?playlist=PLabc123`)
- **Add pagination** (12 videos per page) with prev/next and numbered page controls

## Test plan

- [ ] `/videos` loads all videos, paginated at 12 per page
- [ ] Clicking a playlist pill filters instantly (no loading spinner)
- [ ] URL updates to `?playlist=slug-name`
- [ ] Pagination controls appear when >12 videos in the filtered set
- [ ] Changing playlist resets to page 1
- [ ] Invalid slug falls back to showing all videos
- [ ] Browser back/forward works with URL state
- [ ] Homepage video grid still works (unchanged API)
- [ ] `npm run build` passes cleanly
- [ ] PlaylistFilter unit tests pass (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)