### PR TITLE
Add shop nav link and featured products

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ POSTMARK_API_KEY=
 POSTMARK_FROM=no-reply@yourdomain.com
 POSTMARK_TO=you@yourdomain.com
 
+# Fourthwall Storefront (for shop product previews on homepage)
+FOURTHWALL_STOREFRONT_TOKEN=
+
 # Sentry (for error tracking and performance monitoring)
 NEXT_PUBLIC_SENTRY_DSN=
 SENTRY_AUTH_TOKEN=

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,8 +2,10 @@ import Image from "next/image";
 import Link from "next/link";
 import { VideoCard } from "@/components/VideoCard";
 import { Newsletter } from "@/components/Newsletter";
+import { ShopPreview } from "@/components/ShopPreview";
 import { TransparentVideo } from "@/components/TransparentVideo";
 import { getLatestVideos } from "@/lib/youtube";
+import { getProducts } from "@/lib/fourthwall";
 import { newsletterFlag } from "@/app/flags";
 import { siteConfig } from "@/site.config";
 import styles from "./styles.module.css";
@@ -16,11 +18,13 @@ const labCoatClips = Array.from(
 export const revalidate = 3600;
 
 export default async function Home() {
-  const [videosResult, showNewsletter] = await Promise.all([
+  const [videosResult, productsResult, showNewsletter] = await Promise.all([
     getLatestVideos(6),
+    getProducts(3),
     newsletterFlag(),
   ]);
   const videos = videosResult.success ? videosResult.data : [];
+  const featuredProducts = productsResult.success ? productsResult.data : [];
 
   return (
     <>
@@ -135,6 +139,24 @@ export default async function Home() {
           </p>
         </div>
       </section>
+
+      {/* Shop Preview */}
+      {featuredProducts.length > 0 && (
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>From the Shop</h2>
+            <a
+              href={siteConfig.social.shop}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.viewAllLink}
+            >
+              Visit Shop →
+            </a>
+          </div>
+          <ShopPreview products={featuredProducts} />
+        </section>
+      )}
 
       {/* What's on the Channel */}
       <section className={styles.section}>

--- a/components/MobileMenu/index.tsx
+++ b/components/MobileMenu/index.tsx
@@ -120,16 +120,29 @@ export function MobileMenu({ links }: MobileMenuProps) {
           data-testid="mobile-menu"
         >
           <div className={styles.menuLinks}>
-            {links.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                className={styles.link}
-                onClick={close}
-              >
-                {link.label}
-              </Link>
-            ))}
+            {links.map((link) =>
+              "external" in link && link.external ? (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.link}
+                  onClick={close}
+                >
+                  {link.label}
+                </a>
+              ) : (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className={styles.link}
+                  onClick={close}
+                >
+                  {link.label}
+                </Link>
+              )
+            )}
             <a
               href={siteConfig.social.youtube}
               target="_blank"

--- a/components/Navigation/index.tsx
+++ b/components/Navigation/index.tsx
@@ -12,12 +12,29 @@ export async function Navigation() {
         <div className={styles.inner}>
           {/* Desktop Navigation */}
           <div className={styles.desktopNav}>
-            {navLinks.map((link) => (
-              <Link key={link.href} href={link.href} className={styles.navLink}>
-                {link.label}
-                <span className={styles.navLinkUnderline} />
-              </Link>
-            ))}
+            {navLinks.map((link) =>
+              "external" in link && link.external ? (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.navLink}
+                >
+                  {link.label}
+                  <span className={styles.navLinkUnderline} />
+                </a>
+              ) : (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className={styles.navLink}
+                >
+                  {link.label}
+                  <span className={styles.navLinkUnderline} />
+                </Link>
+              )
+            )}
             <a
               href={siteConfig.social.youtube}
               target="_blank"

--- a/components/ShopPreview/index.tsx
+++ b/components/ShopPreview/index.tsx
@@ -1,0 +1,60 @@
+import Image from "next/image";
+import type { FourthwallProduct } from "@/types/fourthwall";
+import { siteConfig } from "@/site.config";
+import styles from "./styles.module.css";
+
+interface ShopPreviewProps {
+  products: FourthwallProduct[];
+}
+
+function formatPrice(value: number, currency: string): string {
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency,
+  }).format(value);
+}
+
+export function ShopPreview({ products }: ShopPreviewProps) {
+  if (products.length === 0) return null;
+
+  return (
+    <div className={styles.grid}>
+      {products.map((product) => {
+        const image = product.images[0];
+        const price = product.variants[0]?.unitPrice;
+
+        return (
+          <a
+            key={product.id}
+            href={`${siteConfig.social.shop}/products/${product.slug}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.card}
+          >
+            {image && (
+              <div className={styles.imageWrap}>
+                <Image
+                  src={image.url}
+                  alt={product.name}
+                  width={image.width}
+                  height={image.height}
+                  className={styles.image}
+                  sizes="(max-width: 768px) 100vw, 33vw"
+                />
+              </div>
+            )}
+            <div className={styles.info}>
+              <h3 className={styles.name}>{product.name}</h3>
+              {price && (
+                <span className={styles.price}>
+                  {formatPrice(price.value, price.currency)}
+                </span>
+              )}
+              <span className={styles.cta}>View in Store</span>
+            </div>
+          </a>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/ShopPreview/styles.module.css
+++ b/components/ShopPreview/styles.module.css
@@ -1,0 +1,81 @@
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+}
+
+@media (min-width: 768px) {
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.card {
+  background-color: color-mix(
+    in srgb,
+    color-mix(in srgb, var(--secondary), var(--accent-orange) 8%),
+    #ffffff 5%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  transition:
+    border-color 0.2s,
+    transform 0.2s;
+}
+
+.card:hover {
+  border-color: color-mix(in srgb, var(--primary) 40%, transparent);
+  transform: translateY(-2px);
+}
+
+.imageWrap {
+  aspect-ratio: 1;
+  overflow: hidden;
+  background-color: color-mix(in srgb, var(--secondary) 50%, transparent);
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s;
+}
+
+.card:hover .image {
+  transform: scale(1.05);
+}
+
+.info {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.name {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.price {
+  color: var(--accent-yellow);
+  font-weight: 600;
+  font-size: 1.125rem;
+}
+
+.cta {
+  margin-top: auto;
+  color: var(--primary-text);
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+.card:hover .cta {
+  text-decoration: underline;
+}

--- a/lib/fourthwall.ts
+++ b/lib/fourthwall.ts
@@ -8,11 +8,7 @@ type ApiResult<T> =
   | { success: false; error: string };
 
 function getStorefrontToken(): string {
-  const token = process.env.FOURTHWALL_STOREFRONT_TOKEN;
-  if (!token && process.env.NODE_ENV === "production") {
-    throw new Error("FOURTHWALL_STOREFRONT_TOKEN is required in production");
-  }
-  return token || "";
+  return process.env.FOURTHWALL_STOREFRONT_TOKEN || "";
 }
 
 /**
@@ -46,7 +42,7 @@ export async function getProducts(
           return { success: false, error: "No storefront token configured" };
         }
 
-        const url = `${STOREFRONT_API_BASE}/collections/all/products?storefront_token=${token}`;
+        const url = `${STOREFRONT_API_BASE}/collections/all/products?storefront_token=${encodeURIComponent(token)}`;
         const response = await fetch(url, {
           next: { revalidate: 3600 },
         });

--- a/lib/fourthwall.ts
+++ b/lib/fourthwall.ts
@@ -1,0 +1,87 @@
+import * as Sentry from "@sentry/nextjs";
+import type { FourthwallProduct } from "@/types/fourthwall";
+
+const STOREFRONT_API_BASE = "https://storefront-api.fourthwall.com/v1";
+
+type ApiResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+function getStorefrontToken(): string {
+  const token = process.env.FOURTHWALL_STOREFRONT_TOKEN;
+  if (!token && process.env.NODE_ENV === "production") {
+    throw new Error("FOURTHWALL_STOREFRONT_TOKEN is required in production");
+  }
+  return token || "";
+}
+
+/**
+ * Shuffle an array using Fisher-Yates
+ */
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+/**
+ * Fetch products from the Fourthwall store.
+ * Returns a random subset when `count` is specified.
+ */
+export async function getProducts(
+  count?: number
+): Promise<ApiResult<FourthwallProduct[]>> {
+  return Sentry.startSpan(
+    {
+      op: "fourthwall.api",
+      name: "getProducts",
+    },
+    async (span) => {
+      try {
+        const token = getStorefrontToken();
+        if (!token) {
+          return { success: false, error: "No storefront token configured" };
+        }
+
+        const url = `${STOREFRONT_API_BASE}/collections/all/products?storefront_token=${token}`;
+        const response = await fetch(url, {
+          next: { revalidate: 3600 },
+        });
+
+        if (!response.ok) {
+          const message = `Fourthwall API error: ${response.status}`;
+          console.error(message);
+          return { success: false, error: message };
+        }
+
+        const data = await response.json();
+        const products: FourthwallProduct[] = (data.results ?? []).map(
+          (p: FourthwallProduct) => ({
+            id: p.id,
+            name: p.name,
+            slug: p.slug,
+            description: p.description,
+            images: p.images,
+            variants: p.variants,
+          })
+        );
+
+        span.setAttribute("fourthwall.product_count", products.length);
+
+        const result = count ? shuffle(products).slice(0, count) : products;
+        return { success: true, data: result };
+      } catch (error) {
+        Sentry.captureException(error);
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Unknown error fetching products";
+        console.error("Error fetching Fourthwall products:", error);
+        return { success: false, error: message };
+      }
+    }
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,10 @@ const nextConfig: NextConfig = {
         hostname: "img.youtube.com",
         pathname: "/vi/**",
       },
+      {
+        protocol: "https",
+        hostname: "cdn.fourthwall.com",
+      },
     ],
     formats: ["image/avif", "image/webp"],
     minimumCacheTTL: 60,
@@ -31,7 +35,7 @@ const nextConfig: NextConfig = {
           {
             key: "Content-Security-Policy",
             value:
-              "default-src 'self'; img-src 'self' https://i.ytimg.com https://img.youtube.com https://www.googletagmanager.com data:; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' https://www.youtube.com https://www.googleapis.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com; frame-src https://www.youtube-nocookie.com; media-src 'self';",
+              "default-src 'self'; img-src 'self' https://i.ytimg.com https://img.youtube.com https://cdn.fourthwall.com https://www.googletagmanager.com data:; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' https://www.youtube.com https://www.googleapis.com https://storefront-api.fourthwall.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com; frame-src https://www.youtube-nocookie.com; media-src 'self';",
           },
           {
             key: "X-Frame-Options",

--- a/site.config.ts
+++ b/site.config.ts
@@ -35,6 +35,7 @@ export const siteConfig = {
     discord: "https://discord.gg/tPdaADbM2N",
     kofi: "https://ko-fi.com/foxyslab",
     kit: "https://kit.co/foxleigh81",
+    shop: "https://shop.foxyslab.com",
   },
 
   // YouTube Channel Configuration
@@ -51,6 +52,11 @@ export const siteConfig = {
       { href: "/blog", label: "Blog" },
       { href: "/resources", label: "Resources" },
       { href: "/videos", label: "Videos" },
+      {
+        href: "https://shop.foxyslab.com",
+        label: "Shop",
+        external: true as const,
+      },
       { href: "/about", label: "About" },
       { href: "/enquiries", label: "Enquiries" },
     ],

--- a/site.config.ts
+++ b/site.config.ts
@@ -55,7 +55,7 @@ export const siteConfig = {
       {
         href: "https://shop.foxyslab.com",
         label: "Shop",
-        external: true as const,
+        external: true,
       },
       { href: "/about", label: "About" },
       { href: "/enquiries", label: "Enquiries" },

--- a/types/fourthwall.ts
+++ b/types/fourthwall.ts
@@ -1,0 +1,26 @@
+export interface FourthwallImage {
+  id: string;
+  url: string;
+  width: number;
+  height: number;
+}
+
+export interface FourthwallPrice {
+  value: number;
+  currency: string;
+}
+
+export interface FourthwallVariant {
+  id: string;
+  name: string;
+  unitPrice: FourthwallPrice;
+}
+
+export interface FourthwallProduct {
+  id: string;
+  name: string;
+  slug: string;
+  description: string;
+  images: FourthwallImage[];
+  variants: FourthwallVariant[];
+}


### PR DESCRIPTION
## Summary

- Adds a **Shop** link to the navigation bar (desktop + mobile) pointing to `shop.foxyslab.com`, with new external link support for nav items
- Integrates the **Fourthwall Storefront API** to fetch products and display 3 random items in a "From the Shop" section on the homepage
- Each product card shows image, name, price, and links out to the store for purchase
- Section gracefully hides when no products are available (missing token, API error, empty store)

## Test plan

- [x] All 119 unit tests passing
- [x] ESLint clean
- [x] TypeScript type-check clean
- [x] Production build succeeds
- [ ] Verify "Shop" nav link opens shop.foxyslab.com in new tab (desktop + mobile)
- [ ] Verify "From the Shop" section appears on homepage with product cards
- [ ] Verify product cards link to correct store product pages
- [ ] Verify section is hidden when `FOURTHWALL_STOREFRONT_TOKEN` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)